### PR TITLE
Add OCI/Docker notebook execution container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ make build-image
 Builds `jupyter-scheduler-k8s:latest` using:
 - Base: `ghcr.io/prefix-dev/pixi:0.50.2-bookworm-slim`
 - Pixi environment management
-- Simple "Hello World" Python application
+- Notebook executor supporting parameter injection and file packaging
 
 ### Kubernetes Development
 
@@ -72,6 +72,7 @@ The project uses:
 - `image/main.py` handles notebook execution via nbconvert (same as jupyter-scheduler)
 - Code follows high quality standards: no over-engineering, meaningful logging only, graceful error handling
 - Parameter injection matches jupyter-scheduler's approach exactly
+- `PACKAGE_INPUT_FOLDER` env var enables copying all files from notebook directory (matching jupyter-scheduler's `package_input_folder` feature)
 
 ## Development Status
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,16 +66,23 @@ The project uses:
 - `kubernetes>=33.1.0` - Kubernetes API client
 - `uv` for build system
 
-## Image Configuration
+## Implementation Notes
 
-The Docker image uses Pixi for environment management:
-- Platforms: `osx-arm64` (configured in `image/pixi.toml`)
-- Start command: Currently placeholder "Put your command to run a notebook as a job here"
+- Container built with Pixi for cross-platform support
+- `image/main.py` handles notebook execution via nbconvert (same as jupyter-scheduler)
+- Code follows high quality standards: no over-engineering, meaningful logging only, graceful error handling
+- Parameter injection matches jupyter-scheduler's approach exactly
 
 ## Development Status
 
-This appears to be an early-stage project with:
-- Basic project structure established
-- Development environment setup complete
-- Core implementation not yet started (empty `__init__.py`)
-- Placeholder application code in `image/main.py`
+- Phase 1: Container implementation ✅
+- Phase 2: K8sExecutionManager (extends jupyter-scheduler's ExecutionManager)
+
+## Code Quality Standards
+
+- **Comments**: Only add comments that explain parts of code that are not evident from the code itself
+- Explain WHY something is done when the reasoning isn't obvious
+- Explain WHAT is being done when the code logic is complex or non-obvious
+- If the code is self-evident, no comment is needed
+- **Quality**: Insist on highest quality standards while avoiding over-engineering
+- **Scope**: Stay strictly within defined scope - no feature creep or unnecessary complexity

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Kubernetes backend for [jupyter-scheduler](https://github.com/jupyter-server/jup
      jupyter-scheduler-k8s:latest
    ```
 
+3. **Test with copying input folder** (using `PACKAGE_INPUT_FOLDER` environment variable):
+   ```bash
+   finch run --rm \
+     -e NOTEBOOK_PATH="/workspace/tests/test_with_data.ipynb" \
+     -e OUTPUT_PATH="/workspace/output.ipynb" \
+     -e PACKAGE_INPUT_FOLDER="true" \
+     -v "$(pwd):/workspace" \
+     jupyter-scheduler-k8s:latest
+   ```
+
 ## Container Environment Variables
 
 | Variable | Required | Default | Description |
@@ -32,6 +42,7 @@ Kubernetes backend for [jupyter-scheduler](https://github.com/jupyter-server/jup
 | `NOTEBOOK_PATH` | Yes | - | Path to notebook file |
 | `OUTPUT_PATH` | Yes | - | Path to save executed notebook |
 | `PARAMETERS` | No | `{}` | JSON parameters to inject |
+| `PACKAGE_INPUT_FOLDER` | No | `false` | Include all files from notebook directory |
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # jupyter-scheduler-k8s
-A Kubernetes backend for Jupyter Scheduler
+
+Kubernetes backend for [jupyter-scheduler](https://github.com/jupyter-server/jupyter-scheduler) - execute notebook jobs in containers.
+
+## Quick Start
+
+**Prerequisites**: 
+- **macOS**: 
+  ```bash
+  brew install finch kind
+  ```
+- **Linux/Windows**: [Finch install guide](https://github.com/runfinch/finch#installation), [Kind install guide](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+
+1. **Build container** (from project root):
+   ```bash
+   make build-image
+   ```
+
+2. **Test with provided notebook**:
+   ```bash
+   finch run --rm \
+     -e NOTEBOOK_PATH="/workspace/tests/test_notebook.ipynb" \
+     -e OUTPUT_PATH="/workspace/output.ipynb" \
+     -v "$(pwd):/workspace" \
+     jupyter-scheduler-k8s:latest
+   ```
+
+## Container Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NOTEBOOK_PATH` | Yes | - | Path to notebook file |
+| `OUTPUT_PATH` | Yes | - | Path to save executed notebook |
+| `PARAMETERS` | No | `{}` | JSON parameters to inject |
+
+## Development Setup
+
+**Prerequisites**: Finch, Kubernetes cluster
+
+**Local cluster with Kind**:
+```bash
+kind create cluster --name jupyter-scheduler-k8s
+kubectl get nodes
+```
+

--- a/image/main.py
+++ b/image/main.py
@@ -1,4 +1,100 @@
 
+"""
+Notebook executor for K8s jobs.
+Reads notebook from NOTEBOOK_PATH, executes it, saves to OUTPUT_PATH.
+"""
+
+import os
+import sys
+import json
+import logging
+
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    """Execute a notebook based on environment variables."""
+    notebook_path = os.environ.get('NOTEBOOK_PATH')
+    output_path = os.environ.get('OUTPUT_PATH')
+    parameters_json = os.environ.get('PARAMETERS', '{}')
+    kernel_name = os.environ.get('KERNEL_NAME', 'python3')
+    timeout = int(os.environ.get('TIMEOUT', '600'))
+    
+    if not notebook_path:
+        logger.error("NOTEBOOK_PATH environment variable is required")
+        sys.exit(1)
+    
+    if not output_path:
+        logger.error("OUTPUT_PATH environment variable is required")
+        sys.exit(1)
+    
+    try:
+        parameters = json.loads(parameters_json) if parameters_json else {}
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid PARAMETERS JSON: {e}")
+        sys.exit(1)
+    
+    try:
+        with open(notebook_path, 'r') as f:
+            nb = nbformat.read(f, as_version=4)
+    except Exception as e:
+        logger.error(f"Failed to read notebook: {e}")
+        sys.exit(1)
+    
+    logger.info(f"Executing notebook with kernel {kernel_name} (timeout: {timeout}s)")
+    if parameters:
+        logger.info(f"Parameters: {parameters}")
+    
+    if parameters:
+        param_assignments = []
+        for key, value in parameters.items():
+            param_assignments.append(f"{key} = {json.dumps(value)}")
+        
+        param_code = "\n".join(param_assignments)
+        param_cell = nbformat.v4.new_code_cell(source=param_code)
+        param_cell.metadata["tags"] = ["injected-parameters"]
+        
+        insert_idx = 0
+        for idx, cell in enumerate(nb.cells):
+            if hasattr(cell, 'metadata') and "tags" in cell.metadata:
+                if "parameters" in cell.metadata["tags"]:
+                    insert_idx = idx + 1
+                    break
+        
+        nb.cells.insert(insert_idx, param_cell)
+    
+    ep = ExecutePreprocessor(timeout=timeout, kernel_name=kernel_name)
+    
+    try:
+        notebook_dir = os.path.dirname(os.path.abspath(notebook_path)) or '.'
+        ep.preprocess(nb, {'metadata': {'path': notebook_dir}})
+        logger.info("Execution completed successfully")
+    except CellExecutionError as e:
+        logger.error(f"Cell execution failed: {e}")
+        logger.info("Saving partially executed notebook")
+    except Exception as e:
+        logger.error(f"Execution failed: {e}")
+        sys.exit(1)
+    
+    try:
+        output_dir = os.path.dirname(output_path)
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+        
+        with open(output_path, 'w') as f:
+            nbformat.write(nb, f)
+        logger.info(f"Output saved: {output_path}")
+    except Exception as e:
+        logger.error(f"Failed to save output: {e}")
+        sys.exit(1)
+
 
 if __name__ == "__main__":
-    print("Hello World!")
+    main()

--- a/image/main.py
+++ b/image/main.py
@@ -8,6 +8,8 @@ import os
 import sys
 import json
 import logging
+import shutil
+from pathlib import Path
 
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
@@ -26,6 +28,7 @@ def main():
     parameters_json = os.environ.get('PARAMETERS', '{}')
     kernel_name = os.environ.get('KERNEL_NAME', 'python3')
     timeout = int(os.environ.get('TIMEOUT', '600'))
+    package_input_folder = os.environ.get('PACKAGE_INPUT_FOLDER', 'false').lower() == 'true'
     
     if not notebook_path:
         logger.error("NOTEBOOK_PATH environment variable is required")
@@ -36,13 +39,19 @@ def main():
         sys.exit(1)
     
     try:
-        parameters = json.loads(parameters_json) if parameters_json else {}
+        parameters = json.loads(parameters_json)
     except json.JSONDecodeError as e:
         logger.error(f"Invalid PARAMETERS JSON: {e}")
         sys.exit(1)
     
+    if package_input_folder:
+        execution_path, execution_dir = copy_input_folder(notebook_path)
+    else:
+        execution_path = notebook_path
+        execution_dir = str(Path(notebook_path).parent.absolute())
+    
     try:
-        with open(notebook_path, 'r') as f:
+        with open(execution_path, 'r') as f:
             nb = nbformat.read(f, as_version=4)
     except Exception as e:
         logger.error(f"Failed to read notebook: {e}")
@@ -51,30 +60,54 @@ def main():
     logger.info(f"Executing notebook with kernel {kernel_name} (timeout: {timeout}s)")
     if parameters:
         logger.info(f"Parameters: {parameters}")
+        inject_parameters(nb, parameters)
     
-    if parameters:
-        param_assignments = []
-        for key, value in parameters.items():
-            param_assignments.append(f"{key} = {json.dumps(value)}")
-        
-        param_code = "\n".join(param_assignments)
-        param_cell = nbformat.v4.new_code_cell(source=param_code)
-        param_cell.metadata["tags"] = ["injected-parameters"]
-        
-        insert_idx = 0
-        for idx, cell in enumerate(nb.cells):
-            if hasattr(cell, 'metadata') and "tags" in cell.metadata:
-                if "parameters" in cell.metadata["tags"]:
-                    insert_idx = idx + 1
-                    break
-        
-        nb.cells.insert(insert_idx, param_cell)
+    execute_notebook(nb, execution_dir, kernel_name, timeout)
+    save_notebook(nb, output_path)
+
+
+def copy_input_folder(notebook_path):
+    """Copy notebook directory to current working directory."""
+    logger.info("Packaging input folder with notebook")
+    source_dir = Path(notebook_path).parent
+    work_dir = Path.cwd()
     
+    shutil.copytree(source_dir, work_dir, dirs_exist_ok=True)
+    
+    notebook_name = Path(notebook_path).name
+    execution_path = str(work_dir / notebook_name)
+    execution_dir = str(work_dir)
+    logger.info(f"Files copied to {work_dir}")
+    
+    return execution_path, execution_dir
+
+
+def inject_parameters(nb, parameters):
+    """Inject parameters into notebook as a new cell."""
+    param_assignments = []
+    for key, value in parameters.items():
+        param_assignments.append(f"{key} = {json.dumps(value)}")
+    
+    param_code = "\n".join(param_assignments)
+    param_cell = nbformat.v4.new_code_cell(source=param_code)
+    param_cell.metadata["tags"] = ["injected-parameters"]
+    
+    insert_idx = 0
+    for idx, cell in enumerate(nb.cells):
+        if hasattr(cell, 'metadata') and "tags" in cell.metadata:
+            if "parameters" in cell.metadata["tags"]:
+                insert_idx = idx + 1
+                break
+    
+    nb.cells.insert(insert_idx, param_cell)
+
+
+def execute_notebook(nb, execution_dir, kernel_name, timeout):
+    """Execute notebook and handle errors gracefully."""
     ep = ExecutePreprocessor(timeout=timeout, kernel_name=kernel_name)
     
     try:
-        notebook_dir = os.path.dirname(os.path.abspath(notebook_path)) or '.'
-        ep.preprocess(nb, {'metadata': {'path': notebook_dir}})
+        ep.preprocess(nb, {'metadata': {'path': execution_dir}})
         logger.info("Execution completed successfully")
     except CellExecutionError as e:
         logger.error(f"Cell execution failed: {e}")
@@ -82,11 +115,14 @@ def main():
     except Exception as e:
         logger.error(f"Execution failed: {e}")
         sys.exit(1)
-    
+
+
+def save_notebook(nb, output_path):
+    """Save notebook to output path, creating directories as needed."""
     try:
-        output_dir = os.path.dirname(output_path)
-        if output_dir:
-            os.makedirs(output_dir, exist_ok=True)
+        output_dir = Path(output_path).parent
+        if str(output_dir):
+            output_dir.mkdir(parents=True, exist_ok=True)
         
         with open(output_path, 'w') as f:
             nbformat.write(nb, f)

--- a/image/pixi.toml
+++ b/image/pixi.toml
@@ -2,11 +2,14 @@
 authors = ["Brian E. Granger <ellisonbg@gmail.com>"]
 channels = ["conda-forge"]
 name = "image"
-platforms = ["osx-arm64"]
+platforms = ["osx-arm64", "linux-aarch64", "linux-64"]
 version = "0.1.0"
 
 [tasks]
-# Main application startup command
-start = "Put your command to run a notebook as a job here"
+start = "python main.py"
 
 [dependencies]
+jupyter = "*"
+nbformat = "*"
+nbconvert = "*"
+ipykernel = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [project]
 name = "jupyter-scheduler-k8s"
 version = "0.1.0"
+description = "Kubernetes backend for jupyter-scheduler - execute notebook jobs in isolated containers"
+readme = "README.md"
 authors = [
-    { name = "Brian E. Granger", email = "ellisonbg@gmail.com" }
+    { name = "Brian E. Granger", email = "ellisonbg@gmail.com" },
+    { name = "Andrii Ieroshenko", email = "ieroshenkoa@gmail.com" }
 ]
 requires-python = ">=3.13"
 dependencies = [

--- a/src/jupyter_scheduler_k8s/__init__.py
+++ b/src/jupyter_scheduler_k8s/__init__.py
@@ -1,0 +1,3 @@
+"""Kubernetes backend for jupyter-scheduler."""
+
+__version__ = "0.1.0"

--- a/tests/data.csv
+++ b/tests/data.csv
@@ -1,0 +1,4 @@
+name,value
+Alice,100
+Bob,200
+Charlie,300

--- a/tests/test_notebook.ipynb
+++ b/tests/test_notebook.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "test-1",
+   "metadata": {},
+   "source": [
+    "# Test Notebook\n",
+    "Simple test for our K8s notebook executor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "test-2",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": "print(\"Hello from container!\")\nresult = 2 + 2\nprint(f\"2 + 2 = {result}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "test-3",
+   "metadata": {},
+   "outputs": [],
+   "source": "print(\"Test notebook executed successfully!\")"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_with_data.ipynb
+++ b/tests/test_with_data.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "# Test Notebook with Data File\n",
+    "This notebook reads data.csv from the same directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "import os\n",
+    "\n",
+    "print(f\"Current directory: {os.getcwd()}\")\n",
+    "print(f\"Files in directory: {os.listdir('.')}\")  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read the CSV file\n",
+    "with open('data.csv', 'r') as f:\n",
+    "    reader = csv.DictReader(f)\n",
+    "    data = list(reader)\n",
+    "\n",
+    "print(\"Data from CSV:\")\n",
+    "for row in data:\n",
+    "    print(f\"  {row['name']}: {row['value']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate total\n",
+    "total = sum(int(row['value']) for row in data)\n",
+    "print(f\"\\nTotal: {total}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Description

OCI/Docker container that executes Jupyter notebooks via environment variables

### Testing 

**Prerequisites:** Finch or different OCI container runtime 

macOS:
```bash
brew install finch
```

Other platforms: please see https://github.com/runfinch/finch#installation

**Testing instructions (run from project root):**
1. Build container:
```bash
make build-image
```

2. Test with provided notebook:
   ```bash
   finch run --rm \
     -e NOTEBOOK_PATH="/workspace/tests/test_notebook.ipynb" \
     -e OUTPUT_PATH="/workspace/output.ipynb" \
     -v "$(pwd):/workspace" \
     jupyter-scheduler-k8s:latest
   ```
3. Test with copying input folder using `PACKAGE_INPUT_FOLDER` environment variable:
   ```bash
   finch run --rm \
     -e NOTEBOOK_PATH="/workspace/tests/test_with_data.ipynb" \
     -e OUTPUT_PATH="/workspace/output.ipynb" \
     -e PACKAGE_INPUT_FOLDER="true" \
     -v "$(pwd):/workspace" \
     jupyter-scheduler-k8s:latest
   ```